### PR TITLE
Remove the possibility to do directory listing

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -39,6 +39,11 @@ func serveFiles(w http.ResponseWriter, r *http.Request) {
 	cm := GetConfigMap()
 
 	if cm == nil {
+		// Disable directory listing
+		if strings.HasSuffix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
 		http.ServeFile(w, r, filepath.Join("./static", r.URL.Path))
 		return
 	}


### PR DESCRIPTION
This PR adds a quick handler to static file serving to ensure that the url does not end in /.

This returns a 404 if a url does end with / which is effectively disabling directory listings.

See this post for more information: alexedwards.net/blog/disable-http-fileserver-directory-listings